### PR TITLE
Fixes 7802 - ensure that qpidd and user and group are created

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,10 @@
 #
 class qpid::config {
 
-  user { 'qpidd':
+  group { $qpid::group:
+    ensure => present
+  } ->
+  user { $qpid::user:
     ensure => present,
     groups => [$qpid::user_groups],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,4 +9,7 @@ class qpid::params {
 
   $user_groups = []
 
+  $user = 'qpidd'
+  $group = 'qpidd'
+
 }


### PR DESCRIPTION
Related pull-requests that fix  #7802
https://github.com/Katello/puppet-katello/pull/45
https://github.com/Katello/puppet-katello_devel/pull/26
https://github.com/Katello/puppet-qpid/pull/11
