### PR TITLE
refs #8175 - Add linkRoutePattern support for dispatch router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1.0
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 2.7.0"
   - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
@@ -17,12 +16,6 @@ env:
   - PUPPET_VERSION="~> 3.6.0"
 matrix:
   exclude:
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.4.0'
   gem "puppet-lint"
+  gem "rspec-core", "< 3.2.0" # https://github.com/rspec/rspec-core/issues/1864
   gem "rspec-puppet", '>= 1'
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper", '>= 0.8.0'

--- a/manifests/router/config.pp
+++ b/manifests/router/config.pp
@@ -9,6 +9,7 @@ class qpid::router::config {
                 '*header*.conf',
                 '*ssl*.conf',
                 '*connector*.conf',
+                '*link_route_pattern*.conf',
                 '*listener*.conf',
                 '*footer*.conf',
               ],

--- a/manifests/router/link_route_pattern.pp
+++ b/manifests/router/link_route_pattern.pp
@@ -1,0 +1,20 @@
+# == Define: qpid::router::link_route_pattern
+#
+# Configure a link route pattern
+#
+# == Parameters
+#
+# $prefix::     Prefix to use
+#
+# $connector::  Connector for this link route pattern
+#
+define qpid::router::link_route_pattern(
+  $prefix    = 'queue.',
+  $connector = 'broker',
+){
+
+  concat_fragment {"qdrouter+link_route_pattern_${name}.conf":
+    content => template('qpid/router/link_route_pattern.conf.erb'),
+  }
+
+}

--- a/spec/classes/qpid_router_config_spec.rb
+++ b/spec/classes/qpid_router_config_spec.rb
@@ -153,5 +153,33 @@ describe 'qpid::client::config' do
         ]
       end
     end
+
+    context 'with link route pattern' do
+      let :pre_condition do
+        'class {"qpid::router":}
+
+         qpid::router::connector { "broker":
+           addr        => "127.0.0.1",
+           port        => "5672",
+           role        => "on-demand",
+           ssl_profile => "router-ssl",
+         }
+
+         qpid::router::link_route_pattern { "broker-link":
+           connector => "broker",
+           prefix    => "unicorn.",
+         }'
+      end
+
+      it 'should have link_route_pattern fragment' do
+        content = subject.resource('concat_fragment', 'qdrouter+link_route_pattern_broker-link.conf').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+          'linkRoutePattern {',
+          '    prefix: unicorn.',
+          '    connector: broker',
+          '}'
+        ]
+      end
+    end
   end
 end

--- a/templates/router/link_route_pattern.conf.erb
+++ b/templates/router/link_route_pattern.conf.erb
@@ -1,0 +1,5 @@
+linkRoutePattern {
+    prefix: <%= @prefix %>
+    connector: <%= @connector %>
+}
+


### PR DESCRIPTION
In order to actually connect an on-demand connector, we need to have support for `linkRoutePatterns`