### PR TITLE
remove qpid-tools package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,5 +22,5 @@ class qpid::params {
   $user = 'qpidd'
   $group = 'qpidd'
 
-  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf', 'python-qpid', 'policycoreutils-python', 'qpid-tools']
-}
+  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf',
+                      'python-qpid', 'policycoreutils-python'] }


### PR DESCRIPTION
The qpid-tools package is a client-side package that is installed by other
modules and can cause conflicts if it is listed here. It is not needed for a
server install.