### PR TITLE
typo fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@
 # $log_level::                Logging level
 #                             type:string
 #
-# $log_to_syslog:             Log to syslog or not
+# $log_to_syslog::            Log to syslog or not
 #                             type:boolean
 #
 # $ssl::                      Use SSL with Qpid


### PR DESCRIPTION
This patch fixes a typo in the params list that prevented kafo from running.