### PR TITLE
Removes brackets around user_group parameter

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class qpid::config
   } ->
   user { $qpid::user:
     ensure => present,
-    groups => [$qpid::user_groups],
+    groups => $qpid::user_groups,
   }
 
   file { $qpid::config_file:


### PR DESCRIPTION
The value defaults to [] already. No need to create an array of arrays.