### PR TITLE
Add qpid::tools package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,8 @@
 #
 class qpid::install {
 
+  include ::qpid::tools
+
   package { $qpid::server_packages:
     ensure => 'installed',
     before => Service['qpidd'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,5 +22,5 @@ class qpid::params {
   $user = 'qpidd'
   $group = 'qpidd'
 
-  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf', 'python-qpid', 'policycoreutils-python', 'qpid-tools']
+  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf', 'python-qpid', 'policycoreutils-python']
 }

--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -1,0 +1,8 @@
+# Class to ensure qpid tools package
+class qpid::tools {
+
+  package { 'qpid-tools':
+    ensure => 'installed',
+  }
+
+}

--- a/spec/classes/qpid_tools_spec.rb
+++ b/spec/classes/qpid_tools_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'qpid::tools' do
+
+ context 'on redhat' do
+    let :facts do
+      {
+        :concat_basedir             => '/tmp',
+        :operatingsystem            => 'RedHat',
+        :operatingsystemrelease     => '6.4',
+        :operatingsystemmajrelease  => '6.4',
+        :osfamily                   => 'RedHat',
+      }
+    end
+
+    it { should contain_package('qpid-tools').with_ensure('installed') }
+  end
+
+end


### PR DESCRIPTION
Some module, such as Pulp, need to ensure the qpid_tools package
is present on a system. This creates a class to isolate qpid tools
to be used by this module and others.