### PR TITLE
Change ssl_port to a string

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class qpid::params {
   $interface = undef
 
   $ssl                     = false
-  $ssl_port                = 5671
+  $ssl_port                = '5671'
   $ssl_cert_db             = undef
   $ssl_cert_password_file  = undef
   $ssl_cert_name           = undef


### PR DESCRIPTION
The validate_re method expects a string and not an integer to be
pased to it. The integer value causes tests to fail on modules
that depend upon this qpid module.