### PR TITLE
don't manage policycoreutils-python, as it is not related to qpid

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,7 @@ class qpid::params {
   $user = 'qpidd'
   $group = 'qpidd'
 
-  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf', 'python-qpid', 'policycoreutils-python']
+  $server_packages = ['qpid-cpp-server', 'qpid-cpp-client', 'python-qpid-qmf', 'python-qpid', ]
 
   $server_store = true
   $server_store_package = 'qpid-cpp-server-linearstore'


### PR DESCRIPTION
And conflicts with other package that we manage separately. We are trying to keep this package updated on our own, even on machines that don't have this qpid package.
