### PR TITLE
Dispatch router log option is 'enable' not 'enabled'

### DIFF
--- a/spec/classes/qpid_router_config_spec.rb
+++ b/spec/classes/qpid_router_config_spec.rb
@@ -226,7 +226,7 @@ describe 'qpid::router::config' do
           content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
             'log {',
             '    module: DEFAULT',
-            '    enabled: debug+',
+            '    enable: debug+',
             '    timestamp: false',
             '    output: /var/log/qpid.log',
             '}'

--- a/templates/router/log.conf.erb
+++ b/templates/router/log.conf.erb
@@ -1,6 +1,6 @@
 log {
     module: <%= @module %>
-    enabled: <%= @level %>
+    enable: <%= @level %>
     timestamp: <%= @timestamp %>
     output: <%= @output %>
 }


### PR DESCRIPTION
Otherwise:

Oct 14 07:57:49 qpid-asymmetric.example.com qdrouterd[25485]: Fri Oct 14 07:57:49 2016 ERROR (error) Python: Exception: Cannot load configuration file /etc/qpid-dispatch/qdrouterd.conf: org.apache.qpid.dispatch.log: Unknown attribute 'enabled' for 'org.apache.qpid.dispatch.log'
