### PR TITLE
Package conflicts during install on CentOS7, fixes #46

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,13 +8,13 @@ class qpid::install {
 
   package { $qpid::server_packages:
     ensure => $qpid::version,
-    before => Service['qpidd'],
+    before => [Service['qpidd'],Package['qpid-tools']],
   }
 
   if ($qpid::server_store) {
     package { $qpid::server_store_package:
       ensure => $qpid::version,
-      before => Service['qpidd'],
+      before => [Service['qpidd'],Package['qpid-tools']],
     }
   }
 }


### PR DESCRIPTION
qpid-tools installs a compat package that blocks client and server if theyre not installed first, fixes #46