### PR TITLE
Configure performance tuning settings for qpid

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   repositories:
     stdlib: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
     concat: 'git://github.com/puppetlabs/puppetlabs-concat.git'
+    systemd: 'git://github.com/camptocamp/puppet-systemd.git'
   symlinks:
     qpid: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,9 @@
 #
 # === Advanced parameters
 #
+# $max_connections::          Maximum number of connections to allow
+#                             type:integer
+#
 # $log_to_syslog::            Log to syslog or not
 #                             type:boolean
 #
@@ -71,12 +74,17 @@ class qpid (
   $ssl_require_client_auth = $qpid::params::ssl_require_client_auth,
   $user_groups             = $qpid::params::user_groups,
   $server_packages         = $qpid::params::server_packages,
+  $max_connections         = $qpid::params::max_connections,
 ) inherits qpid::params {
 
   validate_string($log_level)
   validate_bool($ssl, $auth, $log_to_syslog)
   validate_array($user_groups)
   validate_array($server_packages)
+
+  if($max_connections) {
+    validate_integer($max_connections)
+  }
 
   if $ssl {
     validate_bool($ssl_require_client_auth)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,8 @@ class qpid::params {
 
   $interface = undef
 
+  $max_connections = undef
+
   $ssl                     = false
   $ssl_port                = '5671'
   $ssl_cert_db             = undef

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -5,13 +5,15 @@
 #
 # == Parameters
 #
-# $router_id::      Unique router ID
+# $router_id::       Unique router ID
 #
-# $container_name:: Unique container name
+# $container_name::  Unique container name
 #
-# $mode::           Router mode
+# $mode::            Router mode
 #
-# $config_file::    Dispatch router config file location
+# $config_file::     Dispatch router config file location
+#
+# $open_file_limit:: Limit number of open files - systemd distros only
 #
 class qpid::router(
   $router_id               = $qpid::router::params::router_id,
@@ -19,6 +21,7 @@ class qpid::router(
   $config_file             = $qpid::router::params::config_file,
   $container_name          = $qpid::router::params::container_name,
   $router_packages         = $qpid::router::params::router_packages,
+  $open_file_limit         = $qpid::router::params::open_file_limit,
 ) inherits qpid::router::params {
 
   class { '::qpid::router::install': } ->

--- a/manifests/router/params.pp
+++ b/manifests/router/params.pp
@@ -9,4 +9,5 @@ class qpid::router::params {
   $container_name      = $::fqdn
   $worker_threads      = $::processorcount
   $router_packages     = ['qpid-dispatch-router']
+  $open_file_limit     = undef
 }

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -11,4 +11,12 @@ class qpid::router::service {
     hasrestart => true,
   }
 
+  if($::qpid::router::open_file_limit and $::systemd) {
+    systemd::service_limits { 'qdrouterd.service':
+      limits  => {
+        'LimitNOFILE' => $::qpid::router::open_file_limit,
+      },
+      require => Service['qdrouterd'],
+    }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.0.0 < 3.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 0.4.0 < 1.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/qpid_config_spec.rb
+++ b/spec/classes/qpid_config_spec.rb
@@ -68,5 +68,23 @@ describe 'qpid::config' do
         end
       end
     end
+
+    context 'with max-connections' do
+      let :pre_condition do
+        'class {"qpid":
+            max_connections => 2000,
+          }'
+      end
+
+      it 'should create configuration file' do
+        content = catalogue.resource('file', '/etc/qpid/qpidd.conf').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+          'log-enable=error+',
+          'log-to-syslog=yes',
+          'auth=no',
+          'max-connections=2000'
+        ]
+      end
+    end
   end
 end

--- a/spec/classes/qpid_router_config_spec.rb
+++ b/spec/classes/qpid_router_config_spec.rb
@@ -4,7 +4,7 @@ describe 'qpid::router::config' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let :facts do
-        facts.merge(:concat_basedir => '/tmp', :processorcount => 2)
+        facts.merge(:concat_basedir => '/tmp', :processorcount => 2, :systemd => true)
       end
 
       context 'without parameters' do
@@ -231,6 +231,19 @@ describe 'qpid::router::config' do
             '    output: /var/log/qpid.log',
             '}'
           ]
+        end
+      end
+
+      context 'with open files limit' do
+        let :pre_condition do
+          'class {"qpid::router":
+             open_file_limit => 10000,
+          }
+          '
+        end
+
+        it 'should configure systemd' do
+          is_expected.to contain_systemd__service_limits('qdrouterd.service') #.with('limits' => { 'LimitNOFILE' => 10000 })
         end
       end
     end

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -41,3 +41,6 @@ ssl-cert-name=<%= scope['qpid::ssl_cert_name'] %>
 <% unless [nil, :undefined, :undef, ''].include?(scope['qpid::interface']) -%>
 interface=<%= scope['qpid::interface'] %>
 <% end %>
+<% unless [nil, :undefined, :undef, ''].include?(scope['qpid::max_connections']) -%>
+max-connections=<%= scope['qpid::max_connections'] %>
+<% end %>


### PR DESCRIPTION
When you have significant numbers of qpid or qdrouterd connections,
you need to set max-connections for qpid, and increase the number
of open files for qdrouterd.