### PR TITLE
Re-factor bind_event to the generic bind action

### DIFF
--- a/manifests/config/bind.pp
+++ b/manifests/config/bind.pp
@@ -1,21 +1,21 @@
-# Define: qpid::bind_event
+# Define: qpid::config::bind
 #
-# This define binds the event queue with the correct messages
+# This define binds the queue with the correct messages
 #
 # === Parameters
 #
-# $queue::                      Name of the event queue
+# $queue::                      Name of the queue
 #
 # $exchange::                   Name of the exchange the queue is on
 #
-# $hostname::                   Set to localhost for qpid-config operations
+# $hostname::                   Hostname of the qpid broker
 #
 # $port::                       Port that qpid is listening on
 #
 # $ssl_cert::                   SSL cert to use for qpid-config commands
-define qpid::bind_event(
+define qpid::config::bind(
   $queue,
-  $exchange = 'event',
+  $exchange,
   $hostname = 'localhost',
   $port = undef,
   $ssl_cert = undef

--- a/manifests/config/exchange.pp
+++ b/manifests/config/exchange.pp
@@ -1,0 +1,29 @@
+# Define: qpid::config::exchange
+#
+# This define ensures an exchange exists
+#
+# === Parameters
+#
+# $exchange::                   Name of the exchange
+#
+# $hostname::                   Hostname of the qpid broker
+#
+# $port::                       Port that qpid is listening on
+#
+# $ssl_cert::                   SSL cert to use for qpid-config commands
+#
+define qpid::config::exchange(
+  $exchange,
+  $hostname = 'localhost',
+  $port = undef,
+  $ssl_cert = undef
+)
+{
+  qpid::config_cmd { "ensure exchange ${title}":
+    command  => "add exchange topic ${exchange} --durable",
+    unless   => "exchanges ${exchange}",
+    hostname => $hostname,
+    port     => $port,
+    ssl_cert => $ssl_cert,
+  }
+}

--- a/manifests/config_cmd.pp
+++ b/manifests/config_cmd.pp
@@ -16,7 +16,8 @@
 # $ssl_cert::                   SSL cert to use for qpid-config commands
 define qpid::config_cmd (
   $command,
-  $onlyif,
+  $onlyif = false,
+  $unless = false,
   $hostname = 'localhost',
   $port = undef,
   $ssl_cert = undef,
@@ -29,11 +30,21 @@ define qpid::config_cmd (
     $base_cmd = "qpid-config -b amqp://${hostname}:${_port}"
   }
 
-  exec { "qpid-config ${title}":
-    command   => "${base_cmd} ${command}",
-    onlyif    => "${base_cmd} ${onlyif}",
-    path      => '/usr/bin',
-    require   => Service['qpidd'],
-    logoutput => true,
+  if $onlyif {
+    exec { "qpid-config ${title}":
+      command   => "${base_cmd} ${command}",
+      onlyif    => "${base_cmd} ${onlyif}",
+      path      => '/usr/bin',
+      require   => Service['qpidd'],
+      logoutput => true,
+    }
+  } elsif $unless {
+    exec { "qpid-config ${title}":
+      command   => "${base_cmd} ${command}",
+      unless    => "${base_cmd} ${unless}",
+      path      => '/usr/bin',
+      require   => Service['qpidd'],
+      logoutput => true,
+    }
   }
 }

--- a/spec/defines/bind_spec.rb
+++ b/spec/defines/bind_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'qpid::bind_event' do
+describe 'qpid::config::bind' do
   let :title do
     '*.*'
   end
@@ -8,6 +8,7 @@ describe 'qpid::bind_event' do
   context 'without ssl_cert' do
     let :params do
       {
+        'exchange' => 'event',
         'queue' => 'myqueue',
       }
     end
@@ -22,6 +23,7 @@ describe 'qpid::bind_event' do
   context 'with ssl_cert' do
     let :params do
       {
+        'exchange' => 'event',
         'queue'    => 'myqueue',
         'ssl_cert' => '/path/to/cert.pem',
       }

--- a/spec/defines/exchange_spec.rb
+++ b/spec/defines/exchange_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'qpid::config::exchange' do
+  let :title do
+    'event'
+  end
+
+  context 'without ssl_cert' do
+    let :params do
+      {
+        'exchange' => 'event',
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('qpid-config ensure exchange event')
+        .with_command('qpid-config -b amqp://localhost:5672 add exchange topic event --durable')
+        .with_unless('qpid-config -b amqp://localhost:5672 exchanges event')
+    end
+  end
+
+  context 'with ssl_cert' do
+    let :params do
+      {
+        'exchange' => 'event',
+        'ssl_cert' => '/path/to/cert.pem',
+      }
+    end
+
+    it do
+      is_expected.to contain_exec('qpid-config ensure exchange event')
+        .with_command('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 add exchange topic event --durable')
+        .with_unless('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 exchanges event')
+    end
+  end
+end


### PR DESCRIPTION
Moves away from having a bind action to a specific exchange and allows
using bind as a generic type as defined by qpid. This change now requires
exchange to be specified.

Ref: https://qpid.apache.org/releases/qpid-0.32/cpp-broker/book/chapter-Managing-CPP-Broker.html