### PR TITLE
config_cmd: optional qpidd, documentation, tests

### DIFF
--- a/manifests/config/bind.pp
+++ b/manifests/config/bind.pp
@@ -13,12 +13,16 @@
 # $port::                       Port that qpid is listening on
 #
 # $ssl_cert::                   SSL cert to use for qpid-config commands
+#
+# $ssl_key::                    SSL key to use for qpid-config commands
+#
 define qpid::config::bind(
   $queue,
   $exchange,
-  $hostname = 'localhost',
+  $hostname = undef,
   $port = undef,
-  $ssl_cert = undef
+  $ssl_cert = undef,
+  $ssl_key = undef,
 )
 {
   qpid::config_cmd { "bind queue to exchange and filter messages that deal with ${title}":
@@ -27,5 +31,6 @@ define qpid::config::bind(
     hostname => $hostname,
     port     => $port,
     ssl_cert => $ssl_cert,
+    ssl_key  => $ssl_key,
   }
 }

--- a/manifests/config/exchange.pp
+++ b/manifests/config/exchange.pp
@@ -12,11 +12,14 @@
 #
 # $ssl_cert::                   SSL cert to use for qpid-config commands
 #
+# $ssl_key::                    SSL key to use for qpid-config commands
+#
 define qpid::config::exchange(
   $exchange,
-  $hostname = 'localhost',
+  $hostname = undef,
   $port = undef,
-  $ssl_cert = undef
+  $ssl_cert = undef,
+  $ssl_key = undef,
 )
 {
   qpid::config_cmd { "ensure exchange ${title}":
@@ -25,5 +28,6 @@ define qpid::config::exchange(
     hostname => $hostname,
     port     => $port,
     ssl_cert => $ssl_cert,
+    ssl_key  => $ssl_key,
   }
 }

--- a/manifests/config_cmd.pp
+++ b/manifests/config_cmd.pp
@@ -9,11 +9,18 @@
 # $onlyif::                     The qpid-config command including parameters to
 #                               check if $command should be executed
 #
+# $unless::                     The qpid-config command including parameters to
+#                               check if $command should not be executed.
+#                               Ignored if $onlyif is specified
+#
 # $hostname::                   The hostname to connect to
 #
 # $port::                       Port that qpid is listening on
 #
 # $ssl_cert::                   SSL cert to use for qpid-config commands
+#
+# $ssl_key::                    SSL key to use for qpid-config commands
+#
 define qpid::config_cmd (
   $command,
   $onlyif = false,
@@ -21,10 +28,13 @@ define qpid::config_cmd (
   $hostname = 'localhost',
   $port = undef,
   $ssl_cert = undef,
+  $ssl_key = undef,
 ) {
-  if $ssl_cert {
+  if $ssl_cert and $ssl_key {
     $_port = pick($port, 5671)
-    $base_cmd = "qpid-config --ssl-certificate ${ssl_cert} -b amqps://${hostname}:${_port}"
+    $base_cmd = "qpid-config --ssl-certificate ${ssl_cert} --ssl-key ${ssl_key} -b amqps://${hostname}:${_port}"
+  } elsif $ssl_cert or $ssl_key {
+    fail('When using SSL both, $ssl_cert and $ssl_key must be specified')
   } else {
     $_port = pick($port, 5672)
     $base_cmd = "qpid-config -b amqp://${hostname}:${_port}"
@@ -35,7 +45,6 @@ define qpid::config_cmd (
       command   => "${base_cmd} ${command}",
       onlyif    => "${base_cmd} ${onlyif}",
       path      => '/usr/bin',
-      require   => Service['qpidd'],
       logoutput => true,
     }
   } elsif $unless {
@@ -43,8 +52,11 @@ define qpid::config_cmd (
       command   => "${base_cmd} ${command}",
       unless    => "${base_cmd} ${unless}",
       path      => '/usr/bin',
-      require   => Service['qpidd'],
       logoutput => true,
     }
+  } else {
+    fail('Either $onlyif or $unless must be specified')
   }
+
+  Service <| tag == 'qpidd' |> -> Exec["qpid-config ${title}"]
 }

--- a/spec/defines/bind_spec.rb
+++ b/spec/defines/bind_spec.rb
@@ -14,9 +14,13 @@ describe 'qpid::config::bind' do
     end
 
     it do
-      is_expected.to contain_exec('qpid-config bind queue to exchange and filter messages that deal with *.*')
-        .with_command('qpid-config -b amqp://localhost:5672 bind event myqueue *.*')
-        .with_onlyif('qpid-config -b amqp://localhost:5672 exchanges event -r | grep *.*')
+      is_expected.to contain_qpid__config_cmd('bind queue to exchange and filter messages that deal with *.*')
+        .with_command('bind event myqueue *.*')
+        .with_onlyif('exchanges event -r | grep *.*')
+        .with_hostname('localhost')
+        .with_port(nil)
+        .with_ssl_cert(nil)
+        .with_ssl_key(nil)
     end
   end
 
@@ -25,14 +29,21 @@ describe 'qpid::config::bind' do
       {
         'exchange' => 'event',
         'queue'    => 'myqueue',
+        'hostname' => 'myhost.example.com',
+        'port'     => 5671,
         'ssl_cert' => '/path/to/cert.pem',
+        'ssl_key'  => '/path/to/key.pem',
       }
     end
 
     it do
-      is_expected.to contain_exec('qpid-config bind queue to exchange and filter messages that deal with *.*')
-        .with_command('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 bind event myqueue *.*')
-        .with_onlyif('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 exchanges event -r | grep *.*')
+      is_expected.to contain_qpid__config_cmd('bind queue to exchange and filter messages that deal with *.*')
+        .with_command('bind event myqueue *.*')
+        .with_onlyif('exchanges event -r | grep *.*')
+        .with_hostname('myhost.example.com')
+        .with_port(5671)
+        .with_ssl_cert('/path/to/cert.pem')
+        .with_ssl_key('/path/to/key.pem')
     end
   end
 end

--- a/spec/defines/config_cmd_spec.rb
+++ b/spec/defines/config_cmd_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe 'qpid::config_cmd' do
+  let (:title) { 'test' }
+
+  on_os_under_test.each do |os, facts|
+    let (:facts) { facts }
+
+    [true, false].each do |qpid|
+      context "qpid => #{qpid}" do
+        context "with unless" do
+          let :params do
+            {
+              'command' => "add exchange topic myexchange --durable",
+              'unless'  => "exchanges myexchange",
+            }
+          end
+
+          if qpid
+            let :pre_condition do
+              'include ::qpid'
+            end
+          end
+
+          it do
+            is_expected.to contain_exec('qpid-config test')
+              .with_command('qpid-config -b amqp://localhost:5672 add exchange topic myexchange --durable')
+              .with_onlyif(nil)
+              .with_unless('qpid-config -b amqp://localhost:5672 exchanges myexchange')
+              .with_path('/usr/bin')
+              .with_logoutput(true)
+
+            if qpid
+              is_expected.to contain_service('qpidd')
+              is_expected.to contain_exec('qpid-config test').that_requires('Service[qpidd]')
+            else
+              is_expected.not_to contain_service('qpidd')
+              is_expected.not_to contain_exec('qpid-config test').that_requires('Service[qpidd]')
+            end
+          end
+        end
+
+        context "with unless" do
+          let :params do
+            {
+              'command' => "bind myexchange myqueue *.*",
+              'onlyif'  => "exchanges myexchange -r | grep *.*",
+            }
+          end
+
+          if qpid
+            let :pre_condition do
+              'include ::qpid'
+            end
+          end
+
+          it do
+            is_expected.to contain_exec('qpid-config test')
+              .with_command('qpid-config -b amqp://localhost:5672 bind myexchange myqueue *.*')
+              .with_onlyif('qpid-config -b amqp://localhost:5672 exchanges myexchange -r | grep *.*')
+              .with_unless(nil)
+              .with_path('/usr/bin')
+              .with_logoutput(true)
+
+            if qpid
+              is_expected.to contain_service('qpidd')
+              is_expected.to contain_exec('qpid-config test').that_requires('Service[qpidd]')
+            else
+              is_expected.not_to contain_service('qpidd')
+              is_expected.not_to contain_exec('qpid-config test').that_requires('Service[qpidd]')
+            end
+          end
+        end
+      end
+    end
+
+    context 'with neither onlyif nor unless' do
+      let :params do
+        {
+          'command' => 'cmd',
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(/Either \$onlyif or \$unless must be specified/) }
+    end
+
+    context 'with SSL' do
+      let :params do
+        {
+          'command'  => 'cmd',
+          'onlyif'   => 'condition',
+          'ssl_cert' => 'cert.pem',
+          'ssl_key'  => 'key.pem',
+        }
+      end
+
+      it do
+        is_expected.to contain_exec('qpid-config test')
+          .with_command('qpid-config --ssl-certificate cert.pem --ssl-key key.pem -b amqps://localhost:5671 cmd')
+          .with_onlyif('qpid-config --ssl-certificate cert.pem --ssl-key key.pem -b amqps://localhost:5671 condition')
+      end
+    end
+
+    context 'with only $ssl_cert' do
+      let :params do
+        {
+          'command'  => 'cmd',
+          'onlyif'   => 'condition',
+          'ssl_cert' => 'cert.pem',
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(/When using SSL both, \$ssl_cert and \$ssl_key must be specified/) }
+    end
+
+    context 'with only $ssl_key' do
+      let :params do
+        {
+          'command' => 'cmd',
+          'onlyif'  => 'condition',
+          'ssl_key' => 'key.pem',
+        }
+      end
+
+      it { is_expected.to compile.and_raise_error(/When using SSL both, \$ssl_cert and \$ssl_key must be specified/) }
+    end
+  end
+end

--- a/spec/defines/exchange_spec.rb
+++ b/spec/defines/exchange_spec.rb
@@ -13,9 +13,13 @@ describe 'qpid::config::exchange' do
     end
 
     it do
-      is_expected.to contain_exec('qpid-config ensure exchange event')
-        .with_command('qpid-config -b amqp://localhost:5672 add exchange topic event --durable')
-        .with_unless('qpid-config -b amqp://localhost:5672 exchanges event')
+      is_expected.to contain_qpid__config_cmd('ensure exchange event')
+        .with_command('add exchange topic event --durable')
+        .with_unless('exchanges event')
+        .with_hostname('localhost')
+        .with_port(nil)
+        .with_ssl_cert(nil)
+        .with_ssl_key(nil)
     end
   end
 
@@ -23,14 +27,21 @@ describe 'qpid::config::exchange' do
     let :params do
       {
         'exchange' => 'event',
+        'hostname' => 'myhost.example.com',
+        'port'     => 5671,
         'ssl_cert' => '/path/to/cert.pem',
+        'ssl_key'  => '/path/to/key.pem',
       }
     end
 
     it do
-      is_expected.to contain_exec('qpid-config ensure exchange event')
-        .with_command('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 add exchange topic event --durable')
-        .with_unless('qpid-config --ssl-certificate /path/to/cert.pem -b amqps://localhost:5671 exchanges event')
+      is_expected.to contain_qpid__config_cmd('ensure exchange event')
+        .with_command('add exchange topic event --durable')
+        .with_unless('exchanges event')
+        .with_hostname('myhost.example.com')
+        .with_port(5671)
+        .with_ssl_cert('/path/to/cert.pem')
+        .with_ssl_key('/path/to/key.pem')
     end
   end
 end


### PR DESCRIPTION
* Makes the dependency on Service[qpidd] optional
* Documents the $unless parameter
* Removes the hardcoded defaults from candlepin::config::*
* Adds tests