### PR TITLE
Support open files limit on qpidd too

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@
 #
 # $wcache_page_size::         The size (in KB) of the pages in the write page cache
 #
+# $open_file_limit::          Limit number of open files - systemd distros only
+#
 # $log_to_syslog::            Log to syslog or not
 #
 # $interface::                Interface to listen on
@@ -66,6 +68,7 @@ class qpid (
   Array[String] $server_packages = $::qpid::params::server_packages,
   Optional[Integer[1]] $max_connections = $::qpid::params::max_connections,
   Optional[Integer[1]] $wcache_page_size = $::qpid::params::wcache_page_size,
+  Optional[Integer[1]] $open_file_limit = $::qpid::params::open_file_limit,
 ) inherits qpid::params {
   if $ssl {
     assert_type(Boolean, $ssl_require_client_auth)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class qpid::params {
   $interface = undef
 
   $max_connections = undef
+  $open_file_limit = undef
 
   $ssl                     = false
   $ssl_port                = 5671

--- a/manifests/router/service.pp
+++ b/manifests/router/service.pp
@@ -11,12 +11,12 @@ class qpid::router::service {
     hasrestart => true,
   }
 
-  if($::qpid::router::open_file_limit and $::systemd) {
+  if $::qpid::router::open_file_limit and $::systemd {
     systemd::service_limits { 'qdrouterd.service':
       limits  => {
         'LimitNOFILE' => $::qpid::router::open_file_limit,
       },
-      require => Service['qdrouterd'],
+      notify  => Service['qdrouterd'],
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,4 +11,12 @@ class qpid::service {
     hasrestart => true,
   }
 
+  if $::qpid::open_file_limit and $::systemd {
+    systemd::service_limits { 'qpidd.service':
+      limits  => {
+        'LimitNOFILE' => $::qpid::open_file_limit,
+      },
+      notify  => Service['qpidd'],
+    }
+  }
 }


### PR DESCRIPTION
I previously added support for qdrouterd open files limit in https://github.com/Katello/puppet-qpid/pull/50, but didn't do it for qpidd.  
