### PR TITLE
Fixes #18812 - update puppet logic on qpid bind

### DIFF
--- a/manifests/config/bind.pp
+++ b/manifests/config/bind.pp
@@ -27,7 +27,7 @@ define qpid::config::bind(
 {
   qpid::config_cmd { "bind queue to exchange and filter messages that deal with ${title}":
     command  => "bind ${exchange} ${queue} ${title}",
-    onlyif   => "exchanges ${exchange} -r | grep ${title}",
+    unless   => "exchanges ${exchange} -r | grep ${title}",
     hostname => $hostname,
     port     => $port,
     ssl_cert => $ssl_cert,

--- a/spec/defines/bind_spec.rb
+++ b/spec/defines/bind_spec.rb
@@ -16,7 +16,7 @@ describe 'qpid::config::bind' do
     it do
       is_expected.to contain_qpid__config_cmd('bind queue to exchange and filter messages that deal with *.*')
         .with_command('bind event myqueue *.*')
-        .with_onlyif('exchanges event -r | grep *.*')
+        .with_unless('exchanges event -r | grep *.*')
         .with_hostname('localhost')
         .with_port(nil)
         .with_ssl_cert(nil)
@@ -39,7 +39,7 @@ describe 'qpid::config::bind' do
     it do
       is_expected.to contain_qpid__config_cmd('bind queue to exchange and filter messages that deal with *.*')
         .with_command('bind event myqueue *.*')
-        .with_onlyif('exchanges event -r | grep *.*')
+        .with_unless('exchanges event -r | grep *.*')
         .with_hostname('myhost.example.com')
         .with_port(5671)
         .with_ssl_cert('/path/to/cert.pem')


### PR DESCRIPTION
Before:
[root@centos7-katello-nightly config]# qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 list binding|grep katello_event_queue
  katello_event_queue                                                           katello_event_queue

After:

[root@centos7-katello-nightly config]# qpid-config --ssl-certificate=/etc/pki/katello/qpid_client_striped.crt -b amqps://localhost:5671 list binding|grep katello_event_queue 
  katello_event_queue                                                           katello_event_queue                                                           0           {}         
  katello_event_queue                                                           compliance.created                                                            0           {}         event
  katello_event_queue                                                           entitlement.created                                                           0           {}         event
  katello_event_queue                                                           entitlement.deleted                                                           0           {}         event
  katello_event_queue                                                           pool.created                                                                  0           {}         event
  katello_event_queue                                                           pool.deleted                                                                  0           {}         event

Showing it ran:

[ WARN 2017-06-14 14:47:26 verbose]  /Stage[main]/Katello::Qpid/Qpid::Config::Bind[entitlement.created]/Qpid::Config_cmd[bind queue to exchange and filter messages that deal with entitlement.created]/Exec[qpid-config bind queue to exchange and filter messages that deal with entitlement.created]/returns: executed successfully
[ WARN 2017-06-14 14:47:27 verbose]  /Stage[main]/Katello::Qpid/Qpid::Config::Bind[entitlement.deleted]/Qpid::Config_cmd[bind queue to exchange and filter messages that deal with entitlement.deleted]/Exec[qpid-config bind queue to exchange and filter messages that deal with entitlement.deleted]/returns: executed successfully
[ WARN 2017-06-14 14:47:27 verbose]  /Stage[main]/Katello::Qpid/Qpid::Config::Bind[pool.created]/Qpid::Config_cmd[bind queue to exchange and filter messages that deal with pool.created]/Exec[qpid-config bind queue to exchange and filter messages that deal with pool.created]/returns: executed successfully
[ WARN 2017-06-14 14:47:27 verbose]  /Stage[main]/Katello::Qpid/Qpid::Config::Bind[pool.deleted]/Qpid::Config_cmd[bind queue to exchange and filter messages that deal with pool.deleted]/Exec[qpid-config bind queue to exchange and filter messages that deal with pool.deleted]/returns: executed successfully
[ WARN 2017-06-14 14:47:27 verbose]  /Stage[main]/Katello::Qpid/Qpid::Config::Bind[compliance.created]/Qpid::Config_cmd[bind queue to exchange and filter messages that deal with compliance.created]/Exec[qpid-config bind queue to exchange and filter messages that deal with compliance.created]/returns: executed successfully
